### PR TITLE
fix: write registry index URLs in cargo config format

### DIFF
--- a/src/cargo_lock_fetch.rs
+++ b/src/cargo_lock_fetch.rs
@@ -198,16 +198,21 @@ fn source_to_dependency_entry(
             Table::from_iter([("git", v(uri)), (ref_type, v(ref_val))])
         }
         SourceKind::Path => Table::from_iter([("path", v(uri))]),
+        // The default registry is left implicit so that cargo resolves it exactly like the
+        // original project would, honoring the default protocol and any source replacement,
+        // and therefore populates the same registry cache.
+        SourceKind::Registry | SourceKind::SparseRegistry if source.is_default_registry() => {
+            Table::from_iter([("version", v(format!("={version}")))])
+        }
+        // In .cargo/config.toml, a registry index is either a bare URL (git index) or a
+        // "sparse+"-prefixed URL; the "registry+" prefix is Cargo.lock's source-id encoding
+        // and is rejected by cargo since 1.96.
         SourceKind::Registry | SourceKind::SparseRegistry => {
-            let registry_uri = [
-                (if *source.kind() == SourceKind::Registry {
-                    "registry"
-                } else {
-                    "sparse"
-                }),
-                uri,
-            ]
-            .join("+");
+            let registry_uri = if *source.kind() == SourceKind::Registry {
+                uri.to_string()
+            } else {
+                format!("sparse+{uri}")
+            };
             Table::from_iter([
                 ("version", v(format!("={version}"))),
                 ("registry", v(registries.get_alias(registry_uri))),
@@ -228,4 +233,69 @@ pub enum SourceError {
 enum Dependency {
     Real(Box<Package>),
     BatchSubCrate(String),
+}
+
+#[cfg(test)]
+mod test {
+    use cargo_lock::SourceId;
+    use itertools::Itertools as _;
+
+    use super::source_to_dependency_entry;
+    use crate::registry_aliases::RegistryAliases;
+
+    fn entry_and_registries(source_url: &str) -> (toml_edit::Table, Vec<(String, String)>) {
+        let source = SourceId::from_url(source_url).expect("source url should parse");
+        let mut registries = RegistryAliases::new();
+        let entry = source_to_dependency_entry("foo", &source, "1.2.3", &mut registries)
+            .expect("registry source should be supported");
+        let registries = registries
+            .iter()
+            .map(|(a, u)| (a.to_owned(), u.to_owned()))
+            .collect_vec();
+        (entry, registries)
+    }
+
+    #[test]
+    fn crates_io_dependency_uses_implicit_registry() {
+        let (entry, registries) =
+            entry_and_registries("registry+https://github.com/rust-lang/crates.io-index");
+
+        assert_eq!(entry["version"].as_str(), Some("=1.2.3"));
+        assert!(!entry.contains_key("registry"));
+        assert_eq!(registries, vec![]);
+    }
+
+    #[test]
+    fn sparse_crates_io_dependency_uses_implicit_registry() {
+        let (entry, registries) = entry_and_registries("sparse+https://index.crates.io/");
+
+        assert!(!entry.contains_key("registry"));
+        assert_eq!(registries, vec![]);
+    }
+
+    #[test]
+    fn git_registry_index_has_no_protocol_prefix() {
+        let (entry, registries) = entry_and_registries("registry+https://example.com/index");
+
+        assert_eq!(
+            registries,
+            vec![(
+                entry["registry"].as_str().unwrap_or_default().to_string(),
+                "https://example.com/index".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn sparse_registry_index_keeps_sparse_prefix() {
+        let (entry, registries) = entry_and_registries("sparse+https://example.com/index/");
+
+        assert_eq!(
+            registries,
+            vec![(
+                entry["registry"].as_str().unwrap_or_default().to_string(),
+                "sparse+https://example.com/index/".to_string()
+            )]
+        );
+    }
 }


### PR DESCRIPTION
Fixes #27.

## Problem

Registry index URLs were copied verbatim from `Cargo.lock` into the generated `.cargo/config.toml`, including the `registry+` source-id prefix:

```toml
[registries.reg1]
index = "registry+https://github.com/rust-lang/crates.io-index"
```

That prefix was never valid in `registries.<name>.index` — cargo's config accepts either a bare URL (git index) or a `sparse+`-prefixed URL. Cargo 1.96 started parsing the value strictly as a URL, treating `registry+https` as the scheme, and fails with:

```
Caused by:
  failed to fetch `registry+https://github.com/rust-lang/crates.io-index`
Caused by:
  invalid argument: 'port'; class=Invalid (3)
```

## Fix

- Write the index in the format cargo config expects: a bare URL for git-index registries, `sparse+<url>` for sparse registries.
- Dependencies from the default registry (crates.io) no longer reference an aliased registry at all. Every lockfile records crates.io as `registry+https://github.com/rust-lang/crates.io-index`, but writing that as a custom git-index registry would make cargo clone the git index and populate the `github.com-*` registry cache — while a normal build of the original project reads the sparse `index.crates.io-*` cache. Leaving the registry implicit makes cargo resolve crates.io exactly like the original project would, honoring the default sparse protocol and any source replacement, so the fetch primes the same cache.

## Testing

- New unit tests cover the source → dependency-entry mapping for both crates.io encodings (`registry+…/crates.io-index`, `sparse+https://index.crates.io/`) and for custom git-index and sparse registries; they fail without the fix.
- `test/test_fetch.sh aho-corasick` passes on rustc 1.96.1 and 1.98.0-nightly (fails on both without the fix); its `cargo fetch --frozen` step confirms the correct registry cache directories are populated.
- `test/test_vendor.sh aho-corasick` passes — output is identical to plain `cargo vendor`.