### PR TITLE
feat: cargo-lock-fetch yanked-version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ dependencies, and this situation is perfectly correct for cargo packages if the 
 in indirectly by different dependencies, `cargo-lock-fetch` distributes the list of dependencies
 between sub-crates using an approach based on greedy vertex coloring, which is optimal for cluster
 graphs (there is an edge between 2 dependencies iff they are different versions of the same crate).
+
+`cargo-lock-fetch` also writes a `Cargo.lock` for the generated package, assembled from the
+package entries of the input lockfile. This matters when the input lockfile pins versions that
+have since been yanked from the registry: cargo refuses to select yanked versions when resolving
+a project from scratch, but versions already recorded in a lockfile are exempt, so fetching and
+vendoring keep working exactly like they do for the original project. Note that passing
+`--locked` or `--frozen` through to cargo may still fail: cargo is allowed to rewrite the
+generated lockfile around feature-dependent edges, which those flags forbid.

--- a/src/cargo_lock_fetch.rs
+++ b/src/cargo_lock_fetch.rs
@@ -19,6 +19,7 @@ use crate::cargo;
 use crate::cargo_config_toml;
 use crate::cargo_toml;
 use crate::cli::CargoLockFetchCli;
+use crate::lockfile_synth;
 use crate::registry_aliases::RegistryAliases;
 
 pub fn main(cli: &CargoLockFetchCli) -> Result<ExitCode, anyhow::Error> {
@@ -26,6 +27,7 @@ pub fn main(cli: &CargoLockFetchCli) -> Result<ExitCode, anyhow::Error> {
 
     let lockfile = Lockfile::load(&cli.lockfile_path)
         .with_context(|| format!("could not load lock file {}", &cli.lockfile_path))?;
+    let resolve_version = lockfile.version;
 
     let dir: Box<dyn AsRef<Path>> = if let Some(ref dir) = cli.tmp_dir {
         Box::new(PathBuf::from_str(dir).unwrap_infallible()) as _
@@ -63,36 +65,41 @@ pub fn main(cli: &CargoLockFetchCli) -> Result<ExitCode, anyhow::Error> {
     }
 
     let mut registries = RegistryAliases::new();
-    let batches = batches::into_batches(packages).collect_vec();
-    let batch_names = batches
-        .into_iter()
+    let batches = batches::into_batches(packages)
         .enumerate()
-        .map(|(i, batch)| -> Result<_, anyhow::Error> {
-            let batch_no = i + 1;
-            let batch_name = format!("batch{batch_no}");
-            cargo::run(
-                dir.as_ref(),
-                "init",
-                [&batch_name, "--name", &batch_name, "--vcs", "none"],
-                cli.quiet,
-            )
-            .with_context(|| format!("failed to create sub-crate for batch {batch_no}"))?;
-            let child = dir.as_ref().as_ref().join(&batch_name);
-            add_packages(
-                child,
-                batch.into_iter().map(|p| Dependency::Real(Box::new(p))),
-                &mut registries,
-            )
-            .with_context(|| format!("failed to add packages for batch {batch_no}"))?;
-            Ok(batch_name)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|(i, batch)| (format!("batch{}", i + 1), batch))
+        .collect_vec();
+    for (batch_name, batch) in &batches {
+        cargo::run(
+            dir.as_ref(),
+            "init",
+            [batch_name.as_str(), "--name", batch_name, "--vcs", "none"],
+            cli.quiet,
+        )
+        .with_context(|| format!("failed to create sub-crate for {batch_name}"))?;
+        let child = dir.as_ref().as_ref().join(batch_name);
+        add_packages(
+            child,
+            batch.iter().map(|p| Dependency::Real(Box::new(p.clone()))),
+            &mut registries,
+        )
+        .with_context(|| format!("failed to add packages for {batch_name}"))?;
+    }
     add_packages(
         dir.as_ref(),
-        batch_names.into_iter().map(Dependency::BatchSubCrate),
+        batches
+            .iter()
+            .map(|(batch_name, _)| Dependency::BatchSubCrate(batch_name.clone())),
         &mut registries,
     )
     .context("failed to add sub-crates as dependencies")?;
+
+    // Written after the manifests so that cargo sees a complete workspace: versions
+    // recorded in a Cargo.lock are exempt from cargo's yank filter, which lockfiles
+    // containing yanked versions rely on.
+    let synthesized = lockfile_synth::synthesize(resolve_version, &batches);
+    lockfile_synth::write_lockfile(dir.as_ref(), &synthesized)
+        .context("failed to write synthesized Cargo.lock")?;
 
     let cargo_status = if let Some(ref vendor_dir) = cli.vendor_dir {
         let absolute_path = std::env::current_dir()

--- a/src/lockfile_synth.rs
+++ b/src/lockfile_synth.rs
@@ -1,0 +1,224 @@
+use std::{iter::once, path::Path, str::FromStr as _};
+
+use anyhow::Context as _;
+use cargo_lock::{Dependency, Lockfile, Name, Package, ResolveVersion, Version};
+use itertools::Itertools as _;
+
+/// Build a Cargo.lock for the generated fake project.
+///
+/// Versions already recorded in a workspace's Cargo.lock are exempt from cargo's yank
+/// filter, so shipping this lockfile lets `cargo fetch`/`cargo vendor` download yanked
+/// versions pinned by the original lockfile. The lockfile does not have to match fresh
+/// resolution exactly: cargo may rewrite it around feature-dependent edges, but keeps
+/// the locked versions, which the manifests pin as `=version` anyway.
+pub fn synthesize(version: ResolveVersion, batches: &[(String, Vec<Package>)]) -> Lockfile {
+    let path_package = |name: &str, dependencies: Vec<Dependency>| Package {
+        name: Name::from_str(name).expect("generated crate name should be valid"),
+        // Matches the version `cargo init` gives the generated manifests; a mismatch
+        // would only make cargo rewrite the entry on the first (non-frozen) resolution.
+        version: Version::new(0, 1, 0),
+        source: None,
+        checksum: None,
+        dependencies,
+        replace: None,
+    };
+
+    let batch_packages = batches
+        .iter()
+        .map(|(name, packages)| path_package(name, packages.iter().map(Dependency::from).collect()))
+        .collect_vec();
+    let fake = path_package(
+        "fake",
+        batch_packages.iter().map(Dependency::from).collect(),
+    );
+
+    let packages = batches
+        .iter()
+        .flat_map(|(_, packages)| packages.iter().cloned())
+        .chain(batch_packages)
+        .chain(once(fake))
+        .collect();
+
+    Lockfile {
+        version,
+        packages,
+        root: None,
+        metadata: Default::default(),
+        patch: Default::default(),
+    }
+}
+
+/// Write the lockfile next to the generated project's root Cargo.toml.
+pub fn write_lockfile(dir: impl AsRef<Path>, lockfile: &Lockfile) -> Result<(), anyhow::Error> {
+    std::fs::write(dir.as_ref().join("Cargo.lock"), lockfile.to_string()).with_context(|| {
+        format!(
+            "Failed to write Cargo.lock in {:?}",
+            dir.as_ref().as_os_str()
+        )
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr as _;
+
+    use cargo_lock::{Lockfile, Package, ResolveVersion};
+    use itertools::Itertools as _;
+
+    use super::synthesize;
+
+    const ORIGINAL_LOCKFILE: &str = r#"
+version = 4
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "myproject"
+version = "1.0.0"
+dependencies = [
+ "core2",
+ "syn 1.0.109",
+ "syn 2.0.118",
+ "uses-old-syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+
+[[package]]
+name = "uses-old-syn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+dependencies = [
+ "syn 1.0.109",
+]
+"#;
+
+    /// Non-local packages of the fixture, batched exactly as `cargo_lock_fetch::main` does.
+    fn named_batches() -> Vec<(String, Vec<Package>)> {
+        let lockfile = Lockfile::from_str(ORIGINAL_LOCKFILE).expect("fixture should parse");
+        let packages = lockfile
+            .packages
+            .into_iter()
+            .filter(|p| p.source.is_some())
+            .map(|p| (p.name.clone(), p))
+            .collect_vec();
+        crate::batches::into_batches(packages)
+            .enumerate()
+            .map(|(i, batch)| (format!("batch{}", i + 1), batch))
+            .collect_vec()
+    }
+
+    fn find<'a>(lockfile: &'a Lockfile, name: &str) -> Vec<&'a Package> {
+        lockfile
+            .packages
+            .iter()
+            .filter(|p| p.name.as_str() == name)
+            .collect_vec()
+    }
+
+    #[test]
+    fn roundtrips_with_fake_root_depending_on_batches() {
+        let batches = named_batches();
+
+        let synthesized = synthesize(ResolveVersion::V4, &batches);
+        let reparsed = Lockfile::from_str(&synthesized.to_string())
+            .expect("synthesized lockfile should parse");
+
+        assert!(reparsed.root.is_none());
+        assert!(reparsed.metadata.is_empty());
+        assert!(reparsed.patch.is_empty());
+        let [fake] = find(&reparsed, "fake")[..] else {
+            panic!("exactly one fake package expected");
+        };
+        assert!(fake.source.is_none());
+        assert!(fake.checksum.is_none());
+        assert_eq!(
+            fake.dependencies
+                .iter()
+                .map(|d| d.name.as_str())
+                .sorted()
+                .collect_vec(),
+            batches
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .sorted()
+                .collect_vec(),
+        );
+    }
+
+    #[test]
+    fn copies_original_package_entries_verbatim() {
+        let batches = named_batches();
+
+        let synthesized = synthesize(ResolveVersion::V4, &batches);
+        let reparsed = Lockfile::from_str(&synthesized.to_string())
+            .expect("synthesized lockfile should parse");
+
+        let originals = Lockfile::from_str(ORIGINAL_LOCKFILE).expect("fixture should parse");
+        for original in originals.packages.iter().filter(|p| p.source.is_some()) {
+            assert!(
+                reparsed.packages.contains(original),
+                "package {} {} should be copied verbatim",
+                original.name.as_str(),
+                original.version,
+            );
+        }
+        assert!(find(&reparsed, "myproject").is_empty());
+    }
+
+    #[test]
+    fn batch_entries_disambiguate_duplicate_versions() {
+        let batches = named_batches();
+
+        let synthesized = synthesize(ResolveVersion::V4, &batches);
+        let reparsed = Lockfile::from_str(&synthesized.to_string())
+            .expect("synthesized lockfile should parse");
+
+        assert_eq!(find(&reparsed, "syn").len(), 2);
+        let syn_deps = reparsed
+            .packages
+            .iter()
+            .filter(|p| p.source.is_none() && p.name.as_str() != "fake")
+            .flat_map(|batch| &batch.dependencies)
+            .filter(|d| d.name.as_str() == "syn")
+            .map(|d| d.version.to_string())
+            .sorted()
+            .collect_vec();
+        assert_eq!(syn_deps, vec!["1.0.109".to_string(), "2.0.118".to_string()]);
+    }
+
+    #[test]
+    fn preserves_resolve_version() {
+        let batches = named_batches();
+
+        let synthesized = synthesize(ResolveVersion::V3, &batches);
+        let reparsed = Lockfile::from_str(&synthesized.to_string())
+            .expect("synthesized lockfile should parse");
+
+        assert_eq!(reparsed.version, ResolveVersion::V3);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod cargo_config_toml;
 mod cargo_lock_fetch;
 mod cargo_toml;
 mod cli;
+mod lockfile_synth;
 mod registry_aliases;
 
 use std::process::ExitCode;

--- a/test/test_all.sh
+++ b/test/test_all.sh
@@ -15,6 +15,10 @@ echo "testing fixture 0 (bootstrap)" >&2
 echo "testing fixture 1 (fetch+vendor, synthetic crates)" >&2
 "$DIR"/test_sets.sh fetch vendor <"$DIR"/sets_fixture_3_10_1_20250727
 
+# lockfiles that pin yanked versions (issue #26)
+echo "testing yanked crate versions" >&2
+"$DIR"/test_yanked.sh
+
 # less popular crates, with more dependencies, large test
 echo "testing fixture 2 (fetch+vendor, synthetic crates)" >&2
 "$DIR"/test_sets.sh fetch vendor <"$DIR"/sets_fixture_3_150_10_20250727

--- a/test/test_yanked.sh
+++ b/test/test_yanked.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# Verify that lockfiles pinning yanked versions still fetch and vendor.
+#
+# Case "partial": crossbeam-channel 0.5.13 is yanked but other 0.5.x
+# versions exist (the exact crate from issue #26); built with cargo and
+# pinned via `cargo update --precise`, which permits yanked versions.
+# Case "allyanked": every version of core2 is yanked, so the reference
+# project cannot be built with cargo at all and is written by hand with
+# checksums recorded from crates.io (immutable once published).
+
+set -e
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/..
+
+cd "$ROOT"
+
+cargo -q build
+TARGET=$(realpath target/debug/cargo-lock-fetch)
+
+D=$(mktemp -d)
+cleanup() {
+	rm -rf "$D"
+}
+trap cleanup EXIT
+
+mkdir "$D/partial"
+cd "$D/partial"
+cargo -q init . --vcs none --name package
+cargo -q add crossbeam-channel@0.5
+cargo -q update crossbeam-channel --precise 0.5.13
+cd - >/dev/null
+
+mkdir "$D/allyanked"
+cd "$D/allyanked"
+cargo -q init . --vcs none --name package
+echo 'core2 = { version = "=0.4.0", default-features = false }' >>Cargo.toml
+cat >Cargo.lock <<'EOF'
+version = 4
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "package"
+version = "0.1.0"
+dependencies = [
+ "core2",
+]
+EOF
+cd - >/dev/null
+
+check() {
+	case=$1
+	crate=$2
+
+	CARGO_HOME="$D/cargo_home_$case"
+	export CARGO_HOME
+	"$TARGET" lock-fetch -q --lockfile-path "$D/$case/Cargo.lock"
+	find "$CARGO_HOME/registry/cache" -name "$crate.crate" | grep -q . || {
+		echo "fail: $crate not fetched for $case"
+		exit 1
+	}
+	(cd "$D/$case" && cargo -q fetch --frozen) || {
+		echo "fail: cargo fetch --frozen failed for $case"
+		exit 1
+	}
+	echo "pass: fetched $case ($crate)"
+
+	(cd "$D/$case" && cargo -q vendor "$D/vendor_expected_$case" --versioned-dirs >/dev/null) || {
+		echo "fail: reference cargo vendor failed for $case"
+		exit 1
+	}
+	"$TARGET" lock-fetch -q --lockfile-path "$D/$case/Cargo.lock" \
+		--vendor "$D/vendor_actual_$case" -- --versioned-dirs
+	if ! diff -Naur "$D/vendor_expected_$case" "$D/vendor_actual_$case" >/dev/null; then
+		echo "fail: vendor mismatch for $case"
+		exit 1
+	fi
+	echo "pass: vendored $case ($crate)"
+	unset CARGO_HOME
+}
+
+check partial crossbeam-channel-0.5.13
+check allyanked core2-0.4.0


### PR DESCRIPTION
Closes #26.

## Problem

Cargo only enforces yank during fresh resolution. Versions already recorded in a
`Cargo.lock` are exempt — that exemption is the only reason any project keeps building
after a dep gets yanked out from under its lockfile. The generated fake project has no
lockfile, so it always resolves fresh and dies on the first yanked pin:

```
error: failed to select a version for the requirement `crossbeam-channel = "=0.5.13"`
  version 0.5.13 is yanked
```

#26 stalled on the assumption that reusing the original lockfile means rebuilding the
project structure around it. Copying it verbatim indeed doesn't work — its root packages
don't match the fake workspace, so cargo discards it wholesale and you're back to fresh
resolution. But the lockfile doesn't have to be the *original* one.

## Change

Synthesize a `Cargo.lock` for the fake project instead. Everything needed is already
parsed out of the input lockfile: every non-local `[[package]]` entry is copied verbatim
(source, checksum, dependency edges), plus path entries for the root crate and each batch
sub-crate. With that in place the fake project gets the same yank exemption the original
had. ~40 lines in a new `lockfile_synth` module; `cargo_lock` already round-trips the
format, including V1–V4 encodings.

The surprising part: the synthesized lockfile doesn't need to match resolution exactly.
The batch manifests say `default-features = false`, so the copied edges can be
feature-stale — cargo just rewrites the lockfile and keeps the locked versions, still
yank-exempt, and the `=version` pins prevent drift. That's also why the fetch/vendor
invocations stay plain (no `--locked`). Vendor output for non-yanked input is unchanged;
I diffed it byte-for-byte against `cargo vendor` of the original project.

This also covers crates where *every* version is yanked — exactly the `core2` situation
that just forced #29 to drop it from the test fixtures. Those are unfixable by
anything that lets cargo resolve freshly, including a `cargo update --precise` repair
loop.

## Testing

Verified on macOS against live crates.io, cargo 1.96 stable and 1.98 nightly.

- Unit tests for `lockfile_synth`: verbatim copying, duplicate-version disambiguation
  across batches, resolve-version preservation, empty `root`/`metadata`/`patch`.
- New `test/test_yanked.sh` (wired into `test_all.sh`), both yank classes, fetch and
  vendor:
  - *partial*: `crossbeam-channel 0.5.13` (the crate from #26); reference project built
    with `cargo update --precise 0.5.13`, which cargo permits for yanked versions;
  - *all-yanked*: `core2 0.4.0`; reference project is hand-written because `cargo add`
    can't construct it anymore.
- Full `./test/test_all.sh` passes locally on this branch after rebasing onto current
  `main`. The yanked test fails on `main` and passes here.

## Notes

- `--locked`/`--frozen` passed through to cargo used to always fail (there was no
  lockfile at all). Now `--locked` works when the synthesized edges happen to match fresh
  resolution, and otherwise fails with cargo's explicit "cannot update the lock file"
  error. Never a silent wrong result.
- A crates.io package literally named `fake` or `batchN` has always collided with the
  generated manifest names; the synthesized lockfile carries that same latent collision,
  unchanged.
