### PR TITLE
ci: skip building example when requiring check-and-lint before release

### DIFF
--- a/.github/workflows/binary-releases.yaml
+++ b/.github/workflows/binary-releases.yaml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/check-and-lint.yaml
+    with:
+      skip-examples: true
   upload-assets:
     needs: ci
     env:

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+      skip-examples:
+        type: boolean
+        default: false
 
 name: Check and Lint
 
@@ -53,6 +57,7 @@ jobs:
 
   build-example:
     name: Build example
+    if: ${{ !inputs.skip-examples }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/check-and-lint.yaml
+    with:
+      skip-examples: true
   publish:
     name: "Publish to crates.io"
     needs: ci

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/check-and-lint.yaml
+    with:
+      skip-examples: true
   docker:
     needs: ci
     runs-on: ubuntu-latest


### PR DESCRIPTION
Obviously, release is required for the examples to build from dockerhub